### PR TITLE
corrected env variable to KAFKA_REST_PROXY_URL

### DIFF
--- a/kafka-topics-ui/templates/deployment.yaml
+++ b/kafka-topics-ui/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
-          - name: KAFKA_REST_URL
+          - name: KAFKA_REST_PROXY_URL
             value: "{{ .Values.kafkaRest.url }}:{{ .Values.kafkaRest.port }}"
           - name: PROXY
             value: "{{ .Values.kafkaRest.proxy }}"


### PR DESCRIPTION
The name of the environment variable used by https://github.com/Landoop/kafka-topics-ui is KAFKA_REST_PROXY_URL instead of KAFKA_REST_URL